### PR TITLE
TechDocs: Fixed race condition issue with changing pages

### DIFF
--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -65,6 +65,8 @@ const useEnforcedTrailingSlash = (): void => {
 };
 
 export const Reader = () => {
+  useEnforcedTrailingSlash();
+
   const location = useLocation();
   const { componentId, '*': path } = useParams();
   const [ref, shadowRoot] = useShadowDom(componentId, path);
@@ -73,8 +75,6 @@ export const Reader = () => {
     `${docStorageURL}${location.pathname.replace('/docs', '')}`,
   ).formatBaseURL();
   const state = useFetch(`${normalizedUrl}index.html`);
-
-  useEnforcedTrailingSlash();
 
   React.useEffect(() => {
     const divElement = shadowDomRef.current;

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -69,7 +69,7 @@ export const Reader = () => {
 
   const location = useLocation();
   const { componentId, '*': path } = useParams();
-  const [ref, shadowRoot] = useShadowDom();
+  const [shadowDomRef, shadowRoot] = useShadowDom();
   const navigate = useNavigate();
   const normalizedUrl = new URLFormatter(
     `${docStorageURL}${location.pathname.replace('/docs', '')}`,
@@ -141,7 +141,7 @@ export const Reader = () => {
   return (
     <>
       <TechDocsPageWrapper title={componentId} subtitle={componentId}>
-        <div ref={ref} />
+        <div ref={shadowDomRef} />
       </TechDocsPageWrapper>
     </>
   );

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -69,7 +69,7 @@ export const Reader = () => {
 
   const location = useLocation();
   const { componentId, '*': path } = useParams();
-  const [ref, shadowRoot] = useShadowDom(componentId, path);
+  const [ref, shadowRoot] = useShadowDom();
   const navigate = useNavigate();
   const normalizedUrl = new URLFormatter(
     `${docStorageURL}${location.pathname.replace('/docs', '')}`,

--- a/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
+++ b/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
@@ -23,7 +23,7 @@ const ComponentWithoutHook = () => {
 };
 
 const ComponentWithHook = () => {
-  const [ref] = useShadowDom('mkdocs', 'about/license/');
+  const [ref] = useShadowDom();
   return <div data-testid="root" ref={ref} />;
 };
 
@@ -31,19 +31,14 @@ describe('useShadowDom', () => {
   it('does not create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithoutHook />);
 
-    const outerDivElement = rendered.getByTestId('root');
-    expect(outerDivElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
-    expect(outerDivElement.children.length).toBe(0);
+    const divElement = rendered.getByTestId('root');
+    expect(divElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
   });
 
   it('create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithHook />);
 
-    const outerDivElement = rendered.getByTestId('root');
-    expect(outerDivElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
-    expect(outerDivElement.children.length).toBe(1);
-
-    const innerDivElement = outerDivElement.children[0];
-    expect(innerDivElement.shadowRoot).toBeInstanceOf(ShadowRoot);
+    const divElement = rendered.getByTestId('root');
+    expect(divElement.shadowRoot).toBeInstanceOf(ShadowRoot);
   });
 });

--- a/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
+++ b/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
@@ -19,26 +19,31 @@ import { renderWithEffects } from '@backstage/test-utils';
 import { useShadowDom } from './shadowDom';
 
 const ComponentWithoutHook = () => {
-  return <div data-testid="shadow-dom" />;
+  return <div data-testid="root" />;
 };
 
 const ComponentWithHook = () => {
-  const ref = useShadowDom();
-  return <div data-testid="shadow-dom" ref={ref} />;
+  const [ref] = useShadowDom('mkdocs', 'about/license/');
+  return <div data-testid="root" ref={ref} />;
 };
 
 describe('useShadowDom', () => {
   it('does not create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithoutHook />);
 
-    const divElement = rendered.getByTestId('shadow-dom');
-    expect(divElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
+    const outerDivElement = rendered.getByTestId('root');
+    expect(outerDivElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
+    expect(outerDivElement.children.length).toBe(0);
   });
 
   it('create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithHook />);
 
-    const divElement = rendered.getByTestId('shadow-dom');
-    expect(divElement.shadowRoot).toBeInstanceOf(ShadowRoot);
+    const outerDivElement = rendered.getByTestId('root');
+    expect(outerDivElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
+    expect(outerDivElement.children.length).toBe(1);
+
+    const innerDivElement = outerDivElement.children[0];
+    expect(innerDivElement.shadowRoot).toBeInstanceOf(ShadowRoot);
   });
 });

--- a/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
+++ b/plugins/techdocs/src/reader/hooks/shadowDom.test.tsx
@@ -19,26 +19,26 @@ import { renderWithEffects } from '@backstage/test-utils';
 import { useShadowDom } from './shadowDom';
 
 const ComponentWithoutHook = () => {
-  return <div data-testid="root" />;
+  return <div data-testid="shadow-dom" />;
 };
 
 const ComponentWithHook = () => {
   const [ref] = useShadowDom();
-  return <div data-testid="root" ref={ref} />;
+  return <div data-testid="shadow-dom" ref={ref} />;
 };
 
 describe('useShadowDom', () => {
   it('does not create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithoutHook />);
 
-    const divElement = rendered.getByTestId('root');
+    const divElement = rendered.getByTestId('shadow-dom');
     expect(divElement.shadowRoot).not.toBeInstanceOf(ShadowRoot);
   });
 
   it('create a Shadow DOM instance', async () => {
     const rendered = await renderWithEffects(<ComponentWithHook />);
 
-    const divElement = rendered.getByTestId('root');
+    const divElement = rendered.getByTestId('shadow-dom');
     expect(divElement.shadowRoot).toBeInstanceOf(ShadowRoot);
   });
 });

--- a/plugins/techdocs/src/reader/hooks/shadowDom.ts
+++ b/plugins/techdocs/src/reader/hooks/shadowDom.ts
@@ -17,14 +17,30 @@
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 
-type IShadowDOMRefObject = RefObject<HTMLDivElement>;
-export const useShadowDom: () => IShadowDOMRefObject = () => {
-  const ref: IShadowDOMRefObject = useRef(null);
+type IUseShadowDOM = (
+  componentId: string,
+  path: string,
+) => [RefObject<HTMLDivElement>, ShadowRoot?];
+
+export const useShadowDom: IUseShadowDOM = (componentId, path) => {
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const divElement = ref.current;
-    divElement?.attachShadow({ mode: 'open' });
-  }, [ref]);
+    const innerDivElement = document.createElement('div');
+    innerDivElement.attachShadow({ mode: 'open' });
 
-  return ref;
+    const outerDivElement = ref.current;
+    outerDivElement?.appendChild(innerDivElement);
+
+    return function cancel() {
+      outerDivElement?.removeChild(innerDivElement);
+    };
+  }, [componentId, path]);
+
+  const shadowRoot =
+    ref.current?.children && ref.current?.children[0].shadowRoot
+      ? ref.current?.children[0].shadowRoot
+      : undefined;
+
+  return [ref, shadowRoot];
 };

--- a/plugins/techdocs/src/reader/hooks/shadowDom.ts
+++ b/plugins/techdocs/src/reader/hooks/shadowDom.ts
@@ -17,30 +17,15 @@
 import { useEffect, useRef } from 'react';
 import type { RefObject } from 'react';
 
-type IUseShadowDOM = (
-  componentId: string,
-  path: string,
-) => [RefObject<HTMLDivElement>, ShadowRoot?];
+type IUseShadowDOM = () => [RefObject<HTMLDivElement>, ShadowRoot?];
 
-export const useShadowDom: IUseShadowDOM = (componentId, path) => {
+export const useShadowDom: IUseShadowDOM = () => {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const innerDivElement = document.createElement('div');
-    innerDivElement.attachShadow({ mode: 'open' });
+    const divElement = ref.current;
+    divElement?.attachShadow({ mode: 'open' });
+  }, []);
 
-    const outerDivElement = ref.current;
-    outerDivElement?.appendChild(innerDivElement);
-
-    return function cancel() {
-      outerDivElement?.removeChild(innerDivElement);
-    };
-  }, [componentId, path]);
-
-  const shadowRoot =
-    ref.current?.children && ref.current?.children[0].shadowRoot
-      ? ref.current?.children[0].shadowRoot
-      : undefined;
-
-  return [ref, shadowRoot];
+  return [ref, ref.current?.shadowRoot || undefined];
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue that we've faced in between page loads, where `useAsync` does not clear the old `state`. We now look for matching URLs with "fetched" content and versus the URL from `window.history`

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [x] Relevant documentation updated
- [x] Prettier run on changed files
- [x] Tests added for new functionality
- [x] Regression tests added for bug fixes
