### PR TITLE
TechDocs: Add onCssReady transformer

### DIFF
--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -137,10 +137,10 @@ export const Reader = () => {
       onCssReady({
         docStorageURL,
         onLoading: (dom: Element) => {
-          dom.style.setProperty('opacity', '0');
+          (dom as HTMLElement).style.setProperty('opacity', '0');
         },
         onLoaded: (dom: Element) => {
-          dom.style.removeProperty('opacity');
+          (dom as HTMLElement).style.removeProperty('opacity');
         },
       }),
     ]);

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -136,10 +136,10 @@ export const Reader = () => {
       }),
       onCssReady({
         docStorageURL,
-        onLoad: dom => {
+        onLoading: (dom: Element) => {
           dom.style.setProperty('opacity', '0');
         },
-        onReady: dom => {
+        onLoaded: (dom: Element) => {
           dom.style.removeProperty('opacity');
         },
       }),

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -146,13 +146,13 @@ export const Reader = () => {
     ]);
   }, [componentId, path, shadowRoot, state]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (state.value instanceof Error) return <TechDocsNotFound />;
+  if (state.value instanceof Error) {
+    return <TechDocsNotFound />;
+  }
 
   return (
-    <>
-      <TechDocsPageWrapper title={componentId} subtitle={componentId}>
-        <div ref={shadowDomRef} />
-      </TechDocsPageWrapper>
-    </>
+    <TechDocsPageWrapper title={componentId} subtitle={componentId}>
+      <div ref={shadowDomRef} />
+    </TechDocsPageWrapper>
   );
 };

--- a/plugins/techdocs/src/reader/components/Reader.tsx
+++ b/plugins/techdocs/src/reader/components/Reader.tsx
@@ -27,6 +27,7 @@ import transformer, {
   addLinkClickListener,
   removeMkdocsHeader,
   modifyCss,
+  onCssReady,
 } from '../transformers';
 import { docStorageURL } from '../../config';
 import URLFormatter from '../urlFormatter';
@@ -131,6 +132,15 @@ export const Reader = () => {
           navigate(`${parsedUrl.pathname}${parsedUrl.hash}`);
 
           shadowRoot?.querySelector(parsedUrl.hash)?.scrollIntoView();
+        },
+      }),
+      onCssReady({
+        docStorageURL,
+        onLoad: dom => {
+          dom.style.setProperty('opacity', '0');
+        },
+        onReady: dom => {
+          dom.style.removeProperty('opacity');
         },
       }),
     ]);

--- a/plugins/techdocs/src/reader/transformers/index.ts
+++ b/plugins/techdocs/src/reader/transformers/index.ts
@@ -19,6 +19,7 @@ export * from './rewriteDocLinks';
 export * from './addLinkClickListener';
 export * from './removeMkdocsHeader';
 export * from './modifyCss';
+export * from './onCssReady';
 
 export type Transformer = (dom: Element) => Element;
 

--- a/plugins/techdocs/src/reader/transformers/onCssReady.test.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  FIXTURES,
+  createTestShadowDom,
+  mockStylesheetEventListener,
+  executeStylesheetEventListeners,
+  clearStylesheetEventListeners,
+} from '../../test-utils';
+import { addBaseUrl, onCssReady } from '../transformers';
+
+const docStorageURL: string =
+  'https://techdocs-mock-sites.storage.googleapis.com';
+
+jest.useFakeTimers();
+
+describe('onCssReady', () => {
+  beforeEach(() => {
+    mockStylesheetEventListener(100);
+  });
+
+  afterEach(() => {
+    clearStylesheetEventListeners();
+  });
+
+  it('does not call onLoading and onLoaded without the addBaseUrl transformer', () => {
+    const onLoading = jest.fn();
+    const onLoaded = jest.fn();
+
+    createTestShadowDom(FIXTURES.FIXTURE_STANDARD_PAGE, {
+      transformers: [
+        onCssReady({
+          docStorageURL,
+          onLoading,
+          onLoaded,
+        }),
+      ],
+    });
+
+    expect(onLoading).not.toHaveBeenCalled();
+    executeStylesheetEventListeners();
+    expect(onLoaded).not.toHaveBeenCalled();
+  });
+
+  it('calls the onLoading and onLoaded correctly', () => {
+    const onLoading = jest.fn();
+    const onLoaded = jest.fn();
+
+    createTestShadowDom(FIXTURES.FIXTURE_STANDARD_PAGE, {
+      transformers: [
+        addBaseUrl({
+          docStorageURL,
+          componentId: 'mkdocs',
+          path: '',
+        }),
+        onCssReady({
+          docStorageURL,
+          onLoading,
+          onLoaded,
+        }),
+      ],
+    });
+
+    expect(onLoading).toHaveBeenCalledTimes(1);
+    expect(onLoading).toHaveBeenCalledWith(expect.any(Element));
+    expect(onLoaded).not.toHaveBeenCalled();
+
+    executeStylesheetEventListeners();
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(onLoaded).toHaveBeenCalledWith(expect.any(Element));
+  });
+});

--- a/plugins/techdocs/src/reader/transformers/onCssReady.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Transformer } from './index';
+
+type OnCssReadyOptions = {
+  docStorageURL: string;
+  onCssLoading: (dom: Element) => void;
+  onCssReady: (dom: Element) => void;
+};
+
+export const onCssReady = ({
+  docStorageURL,
+  onLoad,
+  onReady,
+}: OnCssReadyOptions): Transformer => {
+  return dom => {
+    const cssPages = Array.from(
+      dom.querySelectorAll('head > link[rel="stylesheet"]'),
+    ).filter(elem => elem.getAttribute('href').startsWith(docStorageURL));
+
+    let count = cssPages.length;
+
+    onLoad(dom);
+
+    cssPages.forEach(cssPage =>
+      cssPage.addEventListener('load', () => {
+        count -= 1;
+
+        if (count === 0) {
+          onReady(dom);
+        }
+      }),
+    );
+  };
+};

--- a/plugins/techdocs/src/reader/transformers/onCssReady.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.ts
@@ -18,19 +18,19 @@ import type { Transformer } from './index';
 
 type OnCssReadyOptions = {
   docStorageURL: string;
-  onCssLoading: (dom: Element) => void;
-  onCssReady: (dom: Element) => void;
+  onLoading: (dom: Element) => void;
+  onLoaded: (dom: Element) => void;
 };
 
 export const onCssReady = ({
   docStorageURL,
-  onLoad,
-  onReady,
+  onLoading,
+  onLoaded,
 }: OnCssReadyOptions): Transformer => {
   return dom => {
     const cssPages = Array.from(
       dom.querySelectorAll('head > link[rel="stylesheet"]'),
-    ).filter(elem => elem.getAttribute('href').startsWith(docStorageURL));
+    ).filter(elem => elem.getAttribute('href')?.startsWith(docStorageURL));
 
     let count = cssPages.length;
 
@@ -43,9 +43,11 @@ export const onCssReady = ({
         count -= 1;
 
         if (count === 0) {
-          onReady(dom);
+          onLoaded(dom);
         }
       }),
     );
+
+    return dom;
   };
 };

--- a/plugins/techdocs/src/reader/transformers/onCssReady.ts
+++ b/plugins/techdocs/src/reader/transformers/onCssReady.ts
@@ -34,7 +34,9 @@ export const onCssReady = ({
 
     let count = cssPages.length;
 
-    onLoad(dom);
+    if (count > 0) {
+      onLoading(dom);
+    }
 
     cssPages.forEach(cssPage =>
       cssPage.addEventListener('load', () => {

--- a/plugins/techdocs/src/test-utils/shadowDom.ts
+++ b/plugins/techdocs/src/test-utils/shadowDom.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Spotify AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import transformer from '../reader/transformers';
+import type { Transformer } from '../reader/transformers';
+
+export type CreateTestShadowDomOptions = {
+  transformers: Transformer[];
+};
+
+export const createTestShadowDom = (
+  fixture: string,
+  opts: CreateTestShadowDomOptions = { transformers: [] },
+): ShadowRoot => {
+  const divElement = document.createElement('div');
+  divElement.attachShadow({ mode: 'open' });
+  document.body.appendChild(divElement);
+
+  const domParser = new DOMParser().parseFromString(fixture, 'text/html');
+  divElement.shadowRoot?.appendChild(domParser.documentElement);
+
+  if (opts.transformers) {
+    transformer(divElement.shadowRoot!.children[0], opts.transformers);
+  }
+
+  return divElement.shadowRoot!;
+};
+
+export const getSample = (
+  shadowDom: ShadowRoot,
+  elementName: string,
+  elementAttribute: string,
+  sampleSize = 2,
+) => {
+  const rootElement = shadowDom.children[0];
+
+  return Array.from(rootElement.getElementsByTagName(elementName))
+    .filter(elem => {
+      return elem.hasAttribute(elementAttribute);
+    })
+    .slice(0, sampleSize)
+    .map(elem => {
+      return elem.getAttribute(elementAttribute);
+    });
+};

--- a/plugins/techdocs/src/test-utils/stylesheets.ts
+++ b/plugins/techdocs/src/test-utils/stylesheets.ts
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 
-import FIXTURE_STANDARD_PAGE from './fixtures/mkdocs-index';
-
-export const FIXTURES = {
-  FIXTURE_STANDARD_PAGE,
+export const mockStylesheetEventListener = (timeToCallbackMs: number): void => {
+  HTMLLinkElement.prototype.addEventListener = (
+    _eventName: string,
+    eventCallback: any,
+  ) => {
+    setTimeout(() => {
+      eventCallback();
+    }, timeToCallbackMs);
+  };
 };
 
-export * from './stylesheets';
-export * from './shadowDom';
+export const executeStylesheetEventListeners = (): void => {
+  jest.runOnlyPendingTimers();
+};
+
+export const clearStylesheetEventListeners = (): void => {
+  HTMLLinkElement.prototype.addEventListener =
+    Element.prototype.addEventListener;
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR is for a change that solves the intermittent issue around loading external CSS stylesheets. It creates a transformer that waits for the stylesheet to trigger the "load" event listener, and then executes some actions against the Shadow DOM.

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes