### PR TITLE
techdocs: remove @backstage/plugin-techdocs as dep

### DIFF
--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@backstage/cli": "^0.1.1-alpha.13",
-    "@backstage/plugin-techdocs": "^0.1.1-alpha.13",
     "chalk": "^4.1.0",
     "commander": "^5.1.0",
     "fs-extra": "^9.0.1",


### PR DESCRIPTION
It is unused, and it's just causing us errors sadly!


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ ] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes