### PR TITLE
TechDocs: Fix techdocs-cli when not running local

### DIFF
--- a/packages/techdocs-cli/bin/techdocs-cli
+++ b/packages/techdocs-cli/bin/techdocs-cli
@@ -21,7 +21,7 @@ const path = require('path');
 const isLocal = require('fs').existsSync(path.resolve(__dirname, '../src'));
 
 if (!isLocal) {
-  require('../dist');
+  require('..');
 } else {
   require('ts-node').register({
     transpileOnly: true,


### PR DESCRIPTION
This fixes techdocs-cli when running non-locally.