### PR TITLE
Techdocs-cli Build Fix

### DIFF
--- a/packages/techdocs-cli/bin/build.sh
+++ b/packages/techdocs-cli/bin/build.sh
@@ -16,9 +16,8 @@
 
 set -e
 
-ROOT_DIR=$(git rev-parse --show-toplevel)
-TECHDOCS_PREVIEW_SOURCE=$ROOT_DIR/plugins/techdocs/dist
-TECHDOCS_PREVIEW_DEST=$ROOT_DIR/packages/techdocs-cli/dist/techdocs-preview-bundle
+TECHDOCS_PREVIEW_SOURCE=../../plugins/techdocs/dist
+TECHDOCS_PREVIEW_DEST=../../packages/techdocs-cli/dist/techdocs-preview-bundle
 
 # Build the CLI
 yarn run backstage-cli -- build --outputs cjs


### PR DESCRIPTION
We're using cloud build in gcp to build/package our backstage deployment
and when you upload your artifacts it will remove all of the .git folder
to minimize the upload causing the techdocs-cli to fail as it relies on
using `git rev-parse` to discover the full path. I changed this to be
statically linked so the reliance on git is no longer there and so that
as long as the structure of your repo doesn't change it should build no
matter where the root folder is placed.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist
<!--- Put an `x` in all the boxes that apply: -->
- [ x] All tests are passing `yarn test`
- [ ] Screenshots attached (for UI changes)
- [ ] Relevant documentation updated
- [ ] Prettier run on changed files
- [ ] Tests added for new functionality
- [ ] Regression tests added for bug fixes
